### PR TITLE
Added multilingual support (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Once the app is installed, if you want the Welcome widget to be displayed by def
 occ config:app:set dashboard layout --value=welcome,recommendations,spreed,mail,calendar
 ```
 
+### Multilingual support
+
+The widget supports different languages by appending `_lang` to the specified filename. So if the original filename is `mywelcome.md`, the widget will look for `mywelcome_sv.md` for a user with Swedish set as their language. If that file is not present, the configured filename will be used.
+
+(If the user has no specific language setting, the default language of the Nextcloud instance will be used.)
+
 ### Screenshot
 
 ![Welcome widget example](img/screenshot1.jpg)

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -102,7 +102,7 @@ class FileService {
 				// 'force_locale' is set to true
 				$userLocale = $systemLocale;
 			}
-		} elseif (empty($userLocal)) {
+		} elseif (empty($userLocale)) {
 			$userLocale = 'en_US';
 		}
 

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -31,14 +31,10 @@ use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
-function startsWith(string $haystack, string $needle): bool {
-	$length = mb_strlen($needle);
-	return (mb_substr($haystack, 0, $length) === $needle);
-}
-
 class FileService {
 
-	public function __construct(private IRootFolder $root,
+	public function __construct(
+		private IRootFolder $root,
 		private IConfig $config,
 		private IURLGenerator $urlGenerator,
 		private LoggerInterface $logger,
@@ -47,17 +43,7 @@ class FileService {
 	) {
 	}
 
-	/**
-	 * @return File|null
-	 * @throws NoUserException
-	 * @throws NotFoundException
-	 * @throws NotPermittedException
-	 */
-	private function getWidgetFile(): ?File {
-		$filePath = $this->config->getAppValue(Application::APP_ID, 'filePath');
-		$userName = $this->config->getAppValue(Application::APP_ID, 'userName');
-		$userId = $this->config->getAppValue(Application::APP_ID, 'userId');
-
+	private function getCurrentUserLanguage(): string {
 		// Get current user so we can get settings
 		$sessionUserId = \OC_User::getUser();
 		// Figure out system's default language, default to "en"
@@ -105,6 +91,21 @@ class FileService {
 		} elseif (empty($userLocale)) {
 			$userLocale = 'en_US';
 		}
+
+		return $userLang;
+	}
+
+	/**
+	 * @return File|null
+	 * @throws NoUserException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	private function getWidgetFile(): ?File {
+		$filePath = $this->config->getAppValue(Application::APP_ID, 'filePath');
+		$userName = $this->config->getAppValue(Application::APP_ID, 'userName');
+		$userId = $this->config->getAppValue(Application::APP_ID, 'userId');
+		$userLang = $this->getCurrentUserLanguage();
 
 		/**
 		 * Note: For some languagues, and German in particular, Nextcloud uses
@@ -165,7 +166,7 @@ class FileService {
 			$supportUserId = null;
 			$supportText = null;
 		}
-		
+
 
 		$file = $this->getWidgetFile();
 		if ($file !== null) {

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -27,7 +27,6 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\IConfig;
 use OCP\IURLGenerator;
-use OCP\IUser;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -59,84 +58,84 @@ class FileService {
 		$userName = $this->config->getAppValue(Application::APP_ID, 'userName');
 		$userId = $this->config->getAppValue(Application::APP_ID, 'userId');
 
-        // Get current user so we can get settings
-        $sessionUserId = \OC_User::getUser();
-        // Figure out system's default language, default to "en"
-        $systemLang = $this->config->getSystemValue('default_language', 'en');
-        if (empty($systemLang)) {
-            // We may need to override this manually because it's apparently
-            // possible to get an empty string here
-            $systemLang = 'en';
-        }
-        // Figure out if system is configured to force a language
-        $systemForceLang = $this->config->getSystemValue('force_language', false);
-        // Figure out system's default locale, default to "en_US"
-        $systemLocale = $this->config->getSystemValue('default_locale', 'en_US');
-        if (empty($systemLocale)) {
-            // We may need to override this manually because it's apparently
-            // possible to get an empty string here
-            $systemLocale = 'en_US';
-        }
-        // Figure out if system is configured to force a locale
-        $systemForceLocale = $this->config->getSystemValue('force_locale', false);
-        //Finally, fetch user's lang and locale settings
-        $userLang = $this->config->getUserValue($sessionUserId, 'core', 'lang', 'en');
-        $userLocale = $this->config->getUserValue($sessionUserId, 'core', 'locale', 'en_US');
-        // Apply defaults
-        if ($systemForceLang !== false && $systemForceLang !== 'false') {
-            if ($systemForceLang !== true && $systemForceLang !== 'true') {
-                // 'force_language' is set to an actual language code
-                $userLang = $systemForceLang;
-            } else {
-                // 'force_language' is set to true
-                $userLang = $systemLang;
-            }
-        } elseif (empty($userLang)) {
-            $userLang = 'en';
-        }
-        if ($systemForceLocale !== false && $systemForceLocale !== 'false') {
-            if ($systemForceLocale !== true && $systemForceLocale !== 'true') {
-                // 'force_locale' is set to an actual language code. This could
-                // possibly not be allowed, but we'll make allowance for it :-)
-                $userLocale = $systemForceLocale;
-            } else {
-                // 'force_locale' is set to true
-                $userLocale = $systemLocale;
-            }
-        } elseif (empty($userLocal)) {
-            $userLocale = 'en_US';
-        }
+		// Get current user so we can get settings
+		$sessionUserId = \OC_User::getUser();
+		// Figure out system's default language, default to "en"
+		$systemLang = $this->config->getSystemValue('default_language', 'en');
+		if (empty($systemLang)) {
+			// We may need to override this manually because it's apparently
+			// possible to get an empty string here
+			$systemLang = 'en';
+		}
+		// Figure out if system is configured to force a language
+		$systemForceLang = $this->config->getSystemValue('force_language', false);
+		// Figure out system's default locale, default to "en_US"
+		$systemLocale = $this->config->getSystemValue('default_locale', 'en_US');
+		if (empty($systemLocale)) {
+			// We may need to override this manually because it's apparently
+			// possible to get an empty string here
+			$systemLocale = 'en_US';
+		}
+		// Figure out if system is configured to force a locale
+		$systemForceLocale = $this->config->getSystemValue('force_locale', false);
+		//Finally, fetch user's lang and locale settings
+		$userLang = $this->config->getUserValue($sessionUserId, 'core', 'lang', 'en');
+		$userLocale = $this->config->getUserValue($sessionUserId, 'core', 'locale', 'en_US');
+		// Apply defaults
+		if ($systemForceLang !== false && $systemForceLang !== 'false') {
+			if ($systemForceLang !== true && $systemForceLang !== 'true') {
+				// 'force_language' is set to an actual language code
+				$userLang = $systemForceLang;
+			} else {
+				// 'force_language' is set to true
+				$userLang = $systemLang;
+			}
+		} elseif (empty($userLang)) {
+			$userLang = 'en';
+		}
+		if ($systemForceLocale !== false && $systemForceLocale !== 'false') {
+			if ($systemForceLocale !== true && $systemForceLocale !== 'true') {
+				// 'force_locale' is set to an actual language code. This could
+				// possibly not be allowed, but we'll make allowance for it :-)
+				$userLocale = $systemForceLocale;
+			} else {
+				// 'force_locale' is set to true
+				$userLocale = $systemLocale;
+			}
+		} elseif (empty($userLocal)) {
+			$userLocale = 'en_US';
+		}
 
-        /**
-         * Note: For some languagues, and German in particular, Nextcloud uses
-         * the full locale for the language setting. This is, apparently, for
-         * historical reasons (ownCloud) For example, informal German has the
-         * lang set to "de", whereas formal German has the lang set to "de_DE".
-         * This will result in a different filename, although they're both
-         * technically german. So it'd be "welcome_de.md" and
-         * "welcome.de_DE.md" in that case. But we'll split the final language
-         * string at _ (underscore) to avoid this.
-         */
-        $tmpSplit = explode('_', $userLang, 2);
-        if (is_array($tmpSplit)) {
-            // We'll assume string is reasonably correct and just use the
-            // first part. This would not handle a situation where the string
-            // looks like "_de_DE", but that's an "invalid" string anyway.
-            $userLang = strtolower($tmpSplit[0]);
-        }
+		/**
+		 * Note: For some languagues, and German in particular, Nextcloud uses
+		 * the full locale for the language setting. This is, apparently, for
+		 * historical reasons (ownCloud) For example, informal German has the
+		 * lang set to "de", whereas formal German has the lang set to "de_DE".
+		 * This will result in a different filename, although they're both
+		 * technically german. So it'd be "welcome_de.md" and
+		 * "welcome.de_DE.md" in that case. But we'll split the final language
+		 * string at _ (underscore) to avoid this.
+		 */
+		$tmpSplit = explode('_', $userLang, 2);
+		if (is_array($tmpSplit)) {
+			// We'll assume string is reasonably correct and just use the
+			// first part. This would not handle a situation where the string
+			// looks like "_de_DE", but that's an "invalid" string anyway.
+			$userLang = strtolower($tmpSplit[0]);
+		}
 
 		if ($filePath && $userName && $userId && $this->userManager->userExists($userId)) {
 			$userFolder = $this->root->getUserFolder($userId);
-            $fileBase = dirname($filePath) . basename($filePath, '.md');
-            $userBase = $fileBase . '_' . $userLang . '.md';
-            // First attempt to locate language specific welcome_xx.md file
+			$fileBase = dirname($filePath) . basename($filePath, '.md');
+			$userBase = $fileBase . '_' . $userLang . '.md';
+			// First attempt to locate language specific welcome_xx.md file
 			if ($userFolder->nodeExists($userBase)) {
 				$file = $userFolder->get($userBase);
 				if ($file instanceof File) {
 					return $file;
 				}
-            }
-            // No language specific file found, use whatever is configured
+			}
+			// No language specific file found, use whatever is configured
 			if ($userFolder->nodeExists($filePath)) {
 				$file = $userFolder->get($filePath);
 				if ($file instanceof File) {

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -8,6 +8,9 @@
  *
  * @author Julien Veyssier
  * @copyright Julien Veyssier 2022
+ *
+ * Addition of multilingual support by Joaquim Homrighausen
+ * 2023-03, github @joho1968
  */
 
 namespace OCA\Welcome\Service;
@@ -24,9 +27,15 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\IConfig;
 use OCP\IURLGenerator;
+use OCP\IUser;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
+
+function startsWith(string $haystack, string $needle): bool {
+	$length = mb_strlen($needle);
+	return (mb_substr($haystack, 0, $length) === $needle);
+}
 
 class FileService {
 
@@ -50,8 +59,84 @@ class FileService {
 		$userName = $this->config->getAppValue(Application::APP_ID, 'userName');
 		$userId = $this->config->getAppValue(Application::APP_ID, 'userId');
 
+        // Get current user so we can get settings
+        $sessionUserId = \OC_User::getUser();
+        // Figure out system's default language, default to "en"
+        $systemLang = $this->config->getSystemValue('default_language', 'en');
+        if (empty($systemLang)) {
+            // We may need to override this manually because it's apparently
+            // possible to get an empty string here
+            $systemLang = 'en';
+        }
+        // Figure out if system is configured to force a language
+        $systemForceLang = $this->config->getSystemValue('force_language', false);
+        // Figure out system's default locale, default to "en_US"
+        $systemLocale = $this->config->getSystemValue('default_locale', 'en_US');
+        if (empty($systemLocale)) {
+            // We may need to override this manually because it's apparently
+            // possible to get an empty string here
+            $systemLocale = 'en_US';
+        }
+        // Figure out if system is configured to force a locale
+        $systemForceLocale = $this->config->getSystemValue('force_locale', false);
+        //Finally, fetch user's lang and locale settings
+        $userLang = $this->config->getUserValue($sessionUserId, 'core', 'lang', 'en');
+        $userLocale = $this->config->getUserValue($sessionUserId, 'core', 'locale', 'en_US');
+        // Apply defaults
+        if ($systemForceLang !== false && $systemForceLang !== 'false') {
+            if ($systemForceLang !== true && $systemForceLang !== 'true') {
+                // 'force_language' is set to an actual language code
+                $userLang = $systemForceLang;
+            } else {
+                // 'force_language' is set to true
+                $userLang = $systemLang;
+            }
+        } elseif (empty($userLang)) {
+            $userLang = 'en';
+        }
+        if ($systemForceLocale !== false && $systemForceLocale !== 'false') {
+            if ($systemForceLocale !== true && $systemForceLocale !== 'true') {
+                // 'force_locale' is set to an actual language code. This could
+                // possibly not be allowed, but we'll make allowance for it :-)
+                $userLocale = $systemForceLocale;
+            } else {
+                // 'force_locale' is set to true
+                $userLocale = $systemLocale;
+            }
+        } elseif (empty($userLocal)) {
+            $userLocale = 'en_US';
+        }
+
+        /**
+         * Note: For some languagues, and German in particular, Nextcloud uses
+         * the full locale for the language setting. This is, apparently, for
+         * historical reasons (ownCloud) For example, informal German has the
+         * lang set to "de", whereas formal German has the lang set to "de_DE".
+         * This will result in a different filename, although they're both
+         * technically german. So it'd be "welcome_de.md" and
+         * "welcome.de_DE.md" in that case. But we'll split the final language
+         * string at _ (underscore) to avoid this.
+         */
+        $tmpSplit = explode('_', $userLang, 2);
+        if (is_array($tmpSplit)) {
+            // We'll assume string is reasonably correct and just use the
+            // first part. This would not handle a situation where the string
+            // looks like "_de_DE", but that's an "invalid" string anyway.
+            $userLang = strtolower($tmpSplit[0]);
+        }
+
 		if ($filePath && $userName && $userId && $this->userManager->userExists($userId)) {
 			$userFolder = $this->root->getUserFolder($userId);
+            $fileBase = dirname($filePath) . basename($filePath, '.md');
+            $userBase = $fileBase . '_' . $userLang . '.md';
+            // First attempt to locate language specific welcome_xx.md file
+			if ($userFolder->nodeExists($userBase)) {
+				$file = $userFolder->get($userBase);
+				if ($file instanceof File) {
+					return $file;
+				}
+            }
+            // No language specific file found, use whatever is configured
 			if ($userFolder->nodeExists($filePath)) {
 				$file = $userFolder->get($filePath);
 				if ($file instanceof File) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -30,5 +30,10 @@
 				<referencedClass name="OC\User\NoUserException" />
 			</errorLevel>
 		</UndefinedDocblockClass>
+		<UndefinedClass>
+			<errorLevel type="suppress">
+                <referencedClass name="OC_User" />
+			</errorLevel>
+		</UndefinedClass>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
### Multilingual support (#32)

The widget supports different languages by appending `_lang` to the specified filename. So if the original filename is `mywelcome.md`, the widget will look for `mywelcome_sv.md` for a user with Swedish set as their language. If that file is not present, the configured filename will be used.

(If the user has no specific language setting, the default language of the Nextcloud instance will be used.)