### PR TITLE
fix: add missing config property in OCA\Welcome\AppInfo\Application

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -22,6 +22,7 @@ use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'welcome';
+	private IConfig $config;
 
 	public function __construct(array $urlParams = []) {
 		parent::__construct(self::APP_ID, $urlParams);


### PR DESCRIPTION
Resolves `Creation of dynamic property OCA\\Welcome\\AppInfo\\Application::$config is deprecated at /var/www/nextcloud/apps/welcome/lib/AppInfo/Application.php#30`